### PR TITLE
fix(client): findRoom iff room parameter is provided

### DIFF
--- a/src/client.lua
+++ b/src/client.lua
@@ -105,7 +105,7 @@ Replay =
     function(...) -- depth, room
         local arg = {...}
         local room = nil
-        if arg[1] then
+        if arg[2] then
             room = DevChat.findRoom(arg[2]) or arg[2]
         else
             room = DevChat.LastReceive.Room


### PR DESCRIPTION
Looks like the guard was checking presence of depth (1st parameter) when it should have been checking presence of room (2nd parameter)

Pesky 1-based Lua typo, methinks :)

Edit: grammar typo